### PR TITLE
Reformatted Changes files as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,24 +1,25 @@
-Revision history for Perl extension Device::SMBus.
+Revision history for Perl module Device::SMBus
 
-0.07
+0.07 2013-09-11
   - nBytes
 
-0.06
+0.06 2013-09-08
   - Switched to Moose
 
-0.05 
-  - Added rest of SMBus routines to the XS File
+0.05 2013-09-08
+    - Added rest of SMBus routines to the XS File
 
-0.04 
-  - Fixed a bug in writeByteData 
-  - Fixed issues due to use of Mo(no lazy and build). Switched to Moo. 
+0.04 2013-09-08
+    - Fixed a bug in writeByteData 
+    - Fixed issues due to use of Mo(no lazy and build). Switched to Moo. 
 
-0.03 Sun Sept   8 3:35:18 2013
-  - Added Basic Functions to SMBus Interface
+0.03 2013-09-07
+    - Added Basic Functions to SMBus Interface
 
-0.02 Sun Sept   8 3:15:11 2013
-  - Added Basic Functions to SMBus Interface
+0.02 2013-09-07
+    - Added Basic Functions to SMBus Interface
 
-0.01  Sat Sep  7 13:18:47 2013
-	- original version; created by h2xs 1.23 with options
-		-xA -b 5.10.0 -li2c-dev -n Device::SMBus linux/i2c-dev.h
+0.01 2013-09-07
+    - original version; created by h2xs 1.23 with options
+        -xA -b 5.10.0 -li2c-dev -n Device::SMBus linux/i2c-dev.h
+


### PR DESCRIPTION
Hi Shantanu,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec. This was mainly a matter of looking up the dates of [your releases on backpan](http://backpan.perl.org/authors/id/S/SH/SHANTANU/) and putting all the release dates in the ISO 8601 date format.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service (http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086

You can check the status of your Changes files for all dists:

> http://changes.cpanhq.org/author/SHANTANU

If you choose you update the others, you can log them in comments on the quest :-)
