### PR TITLE
add writeBlockData method

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -6,7 +6,7 @@ Device::SMBus - Perl interface for smbus using libi2c-dev library.
 
 =head1 VERSION
 
-version 1.05
+version 1.06
 
 =head1 SYNOPSIS
 
@@ -137,6 +137,13 @@ $self->writeWordData($register_address,$value)
 
 $self->processCall($register_address,$value)
 
+=head2 writeBlockData
+
+$self->writeBlockData($register_address, $values)
+
+Writes a maximum of 32 bytes in a single block to the i2c device.  The supplied $values should be
+an array ref containing the bytes to be written.
+
 =head2 DEMOLISH
 
 Destructor
@@ -229,3 +236,4 @@ This software is copyright (c) 2013 by Shantanu Bhadoria.
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
 
+=cut

--- a/lib/Device/SMBus.pm
+++ b/lib/Device/SMBus.pm
@@ -196,6 +196,28 @@ sub processCall {
     my $retval = Device::SMBus::_processCall($self->I2CBusFilenumber,$register_address,$value);
 }
 
+=method writeBlockData
+
+$self->writeBlockData($register_address, $values)
+
+Writes a maximum of 32 bytes in a single block to the i2c device.  The supplied $values should be
+an array ref containing the bytes to be written.
+
+The register address should be one that is at the beginning of a contiguous block of registers of equal lengh
+to the array of values passed.  Not adhering to this will almost certainly result in unexpected behaviour in
+the device.
+
+=cut
+
+sub writeBlockData {
+    my ( $self, $register_address, $values ) = @_;
+    
+    my $value  = pack "C*", @{$values};
+
+    my $retval = Device::SMBus::_writeI2CBlockData($self->I2CBusFilenumber,$register_address, $value);
+    return $retval;
+}
+
 # Preloaded methods go here.
 =method DEMOLISH
 


### PR DESCRIPTION
Hi,
Thanks for making Device::SMBus.

I have used it to make Device::PiGlow and it works great.

I noticed that you implemented the XS code for the block write but didn't expose it in the Perl API,  this implements that.

I've actually implemented it directly in my code, and it works fine as implemented (for what I wanted to do.) So know rush to make a release :)

Because I don't have a device that I can read from I didn't implement the read block data :)
