### PR TITLE
Fix non-deterministic destruction issue

### DIFF
--- a/lib/Device/SMBus.pm
+++ b/lib/Device/SMBus.pm
@@ -293,7 +293,7 @@ Destructor
 
 sub DEMOLISH {
     my ($self) = @_;
-    $self->I2CBusFileHandle->close();
+    $self->I2CBusFileHandle->close() if defined($self->I2CBusFileHandle);
 }
 
 1;


### PR DESCRIPTION
When the destruction method runs, it is possible for the file handle to
already be closed (and set to undef), resulting in an error message.
This validates that the file handle is defined before closing it.

It's a one line change - pretty trivial.  I don't know how to write a test for this, unfortunately.

For example, in my code, I had a global variable that stored the Device::SMBus object.  I had a global block that instantiated the object and called a routine that used that global object to read a value.  When Perl's execution finished, I'd get this error message:

        (in cleanup) Can't call method "close" on an undefined value at /home/jmaslak/perl5/perlbrew/perls/perl-5.22.0/lib/site_perl/5.22.0/armv6l-linux/Device/SMBus.pm line 169 during global destruction.

I can work around this by manually undefining the object, but this trivial fix will avoid the problem.  I'm no expert on Perl's object lifecycle, so feel free to reject or modify this if there are better ways of doing this.